### PR TITLE
Better type safety for addPlane; fix a bug it revealed

### DIFF
--- a/src-engine/Engine.ts
+++ b/src-engine/Engine.ts
@@ -303,14 +303,11 @@ export function platform():string {
 //     scene = e;
 // }
 
-export function addPlane(Type:any, args?:any):Plane {
-    if (!(Type.prototype instanceof Plane)) {
-        throw new TypeError("Type passed to addPlane() must inherit from Plane.");
-    }
-
-    var plane = new Type(args || {});
+export function addPlane<p extends Plane>(Type:{new(args:any): p;}, args?:any):p {
+    let plane = new Type(args || {});
     cozyState.planes.push(plane);
-    plane.resize(cozyState.sizeMultiplier);
+    
+    plane.resize(cozyState.config['width'], cozyState.config['height'], cozyState.sizeMultiplier);
 
     return plane;
 }


### PR DESCRIPTION
This syntax allows you to return the correct Plane type. Also it exposed a bug which I _think_ I fixed correctly based on fixZoom.